### PR TITLE
feat: support JSON files [ON HOLD]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "typescript.tsc.autoDetect": "off",
     "workbench.colorCustomizations": {
         "activityBar.background": "#232323",
+        "activityBar.activeBackground": "#232323",
         "activityBar.activeBorder": "#606020",
         "activityBar.foreground": "#e7e7e7",
         "activityBar.inactiveForeground": "#e7e7e799",
@@ -24,8 +25,7 @@
         "statusBar.foreground": "#e7e7e7",
         "panel.border": "#232323",
         "sideBar.border": "#232323",
-        "editorGroup.border": "#232323",
-        "tab.activeBorder": "#232323"
+        "editorGroup.border": "#232323"
     },
     "peacock.color": "#0a0a0a"
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         },
         "cloak.environmentKeys": {
           "type": "string",
-          "default": "string.quoted.double.env,constant.numeric.env,source.env,string.quoted.double.json,constant.numeric.json",
+          "default": "string.quoted.double,string.quoted.single,constant.numeric",
           "description": "Specifies the scopes for the secret keys that will be affected"
         },
         "cloak.environmentComments": {
@@ -138,5 +138,6 @@
     "vscode-test": "^1.2.2",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"
-  }
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -61,13 +61,13 @@
         },
         "cloak.environmentKeys": {
           "type": "string",
-          "default": "string.quoted.double.env,source.env,constant.numeric.env",
-          "description": "Specifies the scopes for the environment keys that will be affected"
+          "default": "string.quoted.double.env,constant.numeric.env,source.env,string.quoted.double.json,constant.numeric.json",
+          "description": "Specifies the scopes for the secret keys that will be affected"
         },
         "cloak.environmentComments": {
           "type": "string",
           "default": "comment.line.number-sign.env",
-          "description": "Specifies the scopes for the environment file comments that will be affected"
+          "description": "Specifies the scopes for the secrets keys that will be affected inside a comment"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -68,6 +68,14 @@
           "type": "string",
           "default": "comment.line.number-sign.env",
           "description": "Specifies the scopes for the secrets keys that will be affected inside a comment"
+        },
+        "cloak.files": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "description": "Identify the files you wish to cloak"
         }
       }
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -21,23 +21,21 @@ export async function restoreDefaultScopesHandler() {
 
 export async function toggleSecretsHandler() {
   const applyRegExp = (fileRegExp: string) => fileName && new RegExp(fileRegExp).test(fileName);
-  const fileGlobs = readConfiguration<string[]>(Settings.Files);
+  const filesToCloak = readConfiguration<string[]>(Settings.Files);
   const filePath = vscode.window.activeTextEditor?.document.uri.fsPath;
   const fileName = filePath?.split(sep).pop();
   let canProcessCurrentFile = true;
 
-  Logger.info({ fileGlobs, fileName });
+  Logger.info({ filesToCloak, fileName });
 
   try {
-    if (Array.isArray(fileGlobs) && fileGlobs.length) {
-      canProcessCurrentFile = !!fileGlobs.find(applyRegExp)?.length;
-    } else if (typeof fileGlobs === 'string') {
-      canProcessCurrentFile = !!applyRegExp(fileGlobs);
-    } else if (typeof fileGlobs === 'undefined') {
-      canProcessCurrentFile = true;
+    if (Array.isArray(filesToCloak) && filesToCloak.length) {
+      canProcessCurrentFile = !!filesToCloak.find(applyRegExp)?.length;
+    } else if (typeof filesToCloak === 'undefined') {
+      canProcessCurrentFile = false;
     } else {
       Logger.info(
-        `Configuration "${Sections.cloakSection}.${Settings.Files}" should be either a glob or an array of globs.`,
+        `Configuration "${Sections.cloakSection}.${Settings.Files}" should be array of files.`,
       );
     }
   } catch (error) {

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -8,7 +8,8 @@ export enum Commands {
 export enum Settings {
   HideComments = 'hideComments',
   EnvironmentKeys = 'environmentKeys',
-  EnvironmentComments = 'environmentComments'
+  EnvironmentComments = 'environmentComments',
+  Files = 'files'
 }
 
 export enum Sections {
@@ -23,11 +24,8 @@ export enum TextMateRulesNames {
 
 export enum TextMateScopeDefaults {
   envKeys = 
-    `string.quoted.double.env,`+
-    `string.quoted.single.env,`+
-    `constant.numeric.env,`+
-    `source.env`+
-    `string.quoted.double.json,`+
-    `constant.numeric.json`,
+    `string.quoted.double`+
+    `string.quoted.single`+
+    `constant.numeric`,
   envComments = 'comment.line.number-sign.env',
 }

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -22,6 +22,12 @@ export enum TextMateRulesNames {
 }
 
 export enum TextMateScopeDefaults {
-  envKeys = 'string.quoted.double.env,string.quoted.single.env,source.env,constant.numeric.env',
+  envKeys = 
+    `string.quoted.double.env,`+
+    `string.quoted.single.env,`+
+    `constant.numeric.env,`+
+    `source.env`+
+    `string.quoted.double.json,`+
+    `constant.numeric.json`,
   envComments = 'comment.line.number-sign.env',
 }

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -23,7 +23,7 @@ export enum TextMateRulesNames {
 }
 
 export enum TextMateScopeDefaults {
-  envKeys = 
+  envKeys =
     `string.quoted.double`+
     `string.quoted.single`+
     `constant.numeric`,

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -14,4 +14,5 @@ export interface ISettings {
   hideComments: boolean;
   environmentKeys: string;
   environmentComments: string;
+  files: string[]
 }


### PR DESCRIPTION
This is a quick PR that adds support for JSON sources. For now, we just process values in double-quotes and numbers (in all JSON files).

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/1699357/78307046-450e9c00-7545-11ea-9a4b-08d1324be48d.gif)

I will try to figure out a way to allow users to select certain files only. But this might require a lot more changes.

Closes #18